### PR TITLE
Fix Boost 1.89.0 compatibility by removing boost_system component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ CPackSourceConfig.cmake
 CPackConfig.cmake
 cmake_install.cmake
 Testing/
-
+install*/
 # common byproducts
 *.pyc
 *.pyo

--- a/cmake/GaudiDependencies.cmake
+++ b/cmake/GaudiDependencies.cmake
@@ -91,12 +91,18 @@ set(THREADS_PREFER_PTHREAD_FLAG YES)
 set(Boost_USE_STATIC_LIBS OFF)
 set(OLD_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}) # FIXME: the day BoostConfig.cmake handles Boost_USE_STATIC_LIBS correctly
 set(BUILD_SHARED_LIBS ON)
-find_package(Boost 1.70 ${__quiet} CONFIG REQUIRED system filesystem regex fiber
+find_package(Boost 1.70 ${__quiet} CONFIG REQUIRED filesystem regex fiber
   thread python unit_test_framework program_options log log_setup graph)
+
+# Boost::system is header-only since 1.69 and removed in 1.89
+# Create an alias to Boost::headers for compatibility
+if(NOT TARGET Boost::system)
+  add_library(Boost::system ALIAS Boost::headers)
+endif()
 
 set(BUILD_SHARED_LIBS ${OLD_BUILD_SHARED_LIBS})
 mark_as_advanced(Boost_DIR) # FIXME: the day Boost correctly marks as advanced its variables
-foreach(component IN ITEMS system filesystem regex thread python unit_test_framework
+foreach(component IN ITEMS filesystem regex thread python unit_test_framework
                            program_options log log_setup graph atomic chrono
                            date_time headers chrono)
   mark_as_advanced(boost_${component}_DIR)


### PR DESCRIPTION
This PR fixes a build failure when using Boost 1.89.0 or later versions.

## Problem

Gaudi fails to build with Boost 1.89.0 with the following error:
```
CMake Error at BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
```

## Root Cause

In Boost 1.89.0, the `boost_system` stub library was completely removed. Boost.System has been header-only since version 1.69, and the backward-compatibility stub library was finally removed in 1.89.0.

Reference: https://www.boost.org/users/history/version_1_89_0.html

## Changes

- Removed `system` from the required Boost components list in `cmake/GaudiDependencies.cmake` (line 94)
- Removed `system` from the `mark_as_advanced` loop (lines 98-100)
- Added a compatibility alias `Boost::system -> Boost::headers` to ensure any downstream code or existing targets that reference `Boost::system` continue to work

## Testing

- [x] Builds successfully with Boost 1.89.0
- [x] Maintains backward compatibility with earlier Boost versions (the alias is only created if the target doesn't already exist)

## Backward Compatibility

This change maintains full backward compatibility:
- Works with Boost 1.70+ (Gaudi's minimum required version)
- Works with Boost 1.89.0+
- The `Boost::system` alias ensures existing code referencing this target continues to function

---

Related issue: #4  